### PR TITLE
Feature/get data gpu

### DIFF
--- a/src/pyzed/sl_c.pxd
+++ b/src/pyzed/sl_c.pxd
@@ -527,6 +527,7 @@ cdef extern from "sl/Camera.hpp" namespace "sl":
 
     ctypedef enum MEM 'sl::MEM':
         CPU 'sl::MEM::CPU'
+        GPU 'sl::MEM::GPU'
 
     MEM operator|(MEM a, MEM b)
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -77,7 +77,7 @@ def check_zed_sdk_version(file_path_):
     else:
         check_zed_sdk_version_private(file_path)
 
-def clean_cpp():
+def clean_cpp(rmslcpp: bool = False):
     if os.path.isfile("pyzed/camera.cpp"):
         os.remove("pyzed/camera.cpp")
     if os.path.isfile("pyzed/core.cpp"):
@@ -88,7 +88,7 @@ def clean_cpp():
         os.remove("pyzed/mesh.cpp")
     if os.path.isfile("pyzed/types.cpp"):
         os.remove("pyzed/types.cpp")
-    if os.path.isfile("pyzed/sl.cpp"):
+    if rmslcpp and os.path.isfile("pyzed/sl.cpp"):
         os.remove("pyzed/sl.cpp")
 
 if "clean" in "".join(sys.argv[1:]):
@@ -100,7 +100,7 @@ else:
 if "cleanall" in "".join(sys.argv[1:]):
     target = "clean"
     print("Deleting Cython files ..")
-    clean_cpp()
+    clean_cpp(rmslcpp=True)
     sys.argv[1] = "clean"
     if os.path.isdir("build"):
         shutil.rmtree("build")

--- a/src/setup.py
+++ b/src/setup.py
@@ -88,6 +88,8 @@ def clean_cpp():
         os.remove("pyzed/mesh.cpp")
     if os.path.isfile("pyzed/types.cpp"):
         os.remove("pyzed/types.cpp")
+    if os.path.isfile("pyzed/sl.cpp"):
+        os.remove("pyzed/sl.cpp")
 
 if "clean" in "".join(sys.argv[1:]):
     target = "clean"


### PR DESCRIPTION
## Keep the `retrieved` data on GPU

### Description

Through the utilization of [cupy.ndarrays](https://docs.cupy.dev/en/stable/reference/ndarray.html) (extra dependency), we were able to keep the retrieved data on GPU and provide a view of the memory on the Python side.

This PR introduces a slight modification to the `get_data()` function in a way that extends the API, but doesn't break any of its current functionalities.

### Notes

In an effort to stay true to the original API, data on the GPU could be either `deeply copied`, or `viewed` by the Python API consumer.

A list of references is kept as a comment above the added code for potential enhancements, and/or better understanding of the feature.

### Tests

This was tested with the `ZED SDK 4.0`, on both SVOs (recorded in HD2K-15), and on a live stream from a `ZED Mini`, with a custom wrapper of the Python API, on a `Ubuntu 20.04.6 LTS` system, with an Nvidia GTX 1650 4Gb graphics card.

Additionally, we are attempting its test on an `Nvidia AGX Orin 32Gb developer kit`, though we're having some Cython compilation errors that are prohibiting us from proceeding with the tests (would love to discuss, but not our topic).

### Disclaimers

This is not thoroughly tested, and this PR is intended to spark a discussion around how this feature might be developed by the community, rather than being a final product (though we hope it's ready as is).
